### PR TITLE
Fix the condition when a variable is undefined

### DIFF
--- a/lua/rooter.lua
+++ b/lua/rooter.lua
@@ -1,7 +1,7 @@
-if vim.g.rooter_pattern == nil then
+if vim.g.rooter_pattern == vim.NIL then
   vim.g.rooter_pattern = {'.git', 'Makefile', '_darcs', '.hg', '.bzr', '.svn', 'node_modules', 'CMakeLists.txt'}
 end
-if vim.g.outermost_root == nil then
+if vim.g.outermost_root == vim.NIL then
   vim.g.outermost_root = true
 end
 


### PR DESCRIPTION
Because I got the following error in version NVIM v0.5.0-dev+1345-g6dd04ed5f.

```
Error detected while processing function <lambda>1956[1]..<SNR>243_start[59]..<SNR>243_pre_hook[8]..<lambda>1962[1]..<SNR>345_pre_hook[21]..<SNR>345_new_win:
line    1:
E5555: API call: Vim(execute):E5108: Error executing lua ...are/nvim/site/pack/packer/opt/rooter.nvim/lua/rooter.lua:42: bad argument #1 to 'ipairs' (table expected, got userdata)
```